### PR TITLE
feat: cubit v0.0.2

### DIFF
--- a/packages/cubit/CHANGELOG.md
+++ b/packages/cubit/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 - **BREAKING**: update `emit` to be a `void` function
 - **BREAKING**: remove artifical wait to guarantee `initialState` is emitted
+- **BREAKING**: `close` drains the internal `Stream`
 - tests: 100% test coverage
 
 # 0.0.1

--- a/packages/cubit/CHANGELOG.md
+++ b/packages/cubit/CHANGELOG.md
@@ -1,3 +1,9 @@
+# 0.0.2
+
+- **BREAKING**: update `emit` to be a `void` function
+- **BREAKING**: remove artifical wait to guarantee `initialState` is emitted
+- tests: 100% test coverage
+
 # 0.0.1
 
-Initial Release
+- feat: initial release

--- a/packages/cubit/README.md
+++ b/packages/cubit/README.md
@@ -15,8 +15,7 @@ class CounterCubit extends Cubit<int> {
   @override
   int get initialState => 0;
 
-  Future<void> increment() => emit(state + 1);
-  Future<void> decrement() => emit(state - 1);
+  void increment() => emit(state + 1);
 }
 ```
 
@@ -24,18 +23,17 @@ class CounterCubit extends Cubit<int> {
 
 ```dart
 void main() async {
-  final counterCubit = CounterCubit()..listen(print);
-  await counterCubit.increment();
-  await counterCubit.decrement();
+  final cubit = CounterCubit()
+    ..listen(print)
+    ..increment();
+  await cubit.close();
 }
 ```
 
 The above code outputs:
 
 ```sh
-0
 1
-0
 ```
 
 ## Dart Versions

--- a/packages/cubit/example/main.dart
+++ b/packages/cubit/example/main.dart
@@ -1,21 +1,15 @@
 import 'package:cubit/cubit.dart';
 
 void main() async {
-  final counterCubit = CounterCubit()..listen(print);
-
-  await counterCubit.increment();
-  await counterCubit.increment();
-  await counterCubit.increment();
-
-  await counterCubit.decrement();
-  await counterCubit.decrement();
-  await counterCubit.decrement();
+  final cubit = CounterCubit()
+    ..listen(print)
+    ..increment();
+  await cubit.close();
 }
 
 class CounterCubit extends Cubit<int> {
   @override
   int get initialState => 0;
 
-  Future<void> increment() => emit(state + 1);
-  Future<void> decrement() => emit(state - 1);
+  void increment() => emit(state + 1);
 }

--- a/packages/cubit/lib/src/cubit.dart
+++ b/packages/cubit/lib/src/cubit.dart
@@ -58,7 +58,7 @@ abstract class Cubit<T> extends Stream<T> {
   @override
   bool get isBroadcast => _controller.stream.isBroadcast;
 
-  /// Closes the stream.
+  /// Closes the `cubit`.
   @mustCallSuper
   Future<void> close() async {
     await _controller.close();

--- a/packages/cubit/lib/src/cubit.dart
+++ b/packages/cubit/lib/src/cubit.dart
@@ -3,8 +3,17 @@ import 'dart:async';
 import 'package:meta/meta.dart';
 
 /// {@template cubit}
-/// `Stream` which exposes a `state` and
-/// can conditionally emit new states asynchronously.
+/// A `cubit` is a reimagined `bloc` (from `package:bloc`)
+/// which removes events and relies on methods to emit new states instead.
+///
+/// ```dart
+/// class CounterCubit extends Cubit<int> {
+///   @override
+///   int get initialState => 0;
+///
+///   void increment() => emit(state + 1);
+/// }
+/// ```
 /// {@endtemplate}
 abstract class Cubit<T> extends Stream<T> {
   /// {@macro cubit}
@@ -22,8 +31,8 @@ abstract class Cubit<T> extends Stream<T> {
 
   T _state;
 
-  /// Updates the cubit's [state] to the provided [state].
-  /// If the `cubit` has been closed, emit will do nothing.
+  /// Updates the [state] of the `cubit` to the provided [state].
+  /// [emit] does nothing if the `cubit` has been closed.
   @protected
   void emit(T state) async {
     if (_controller.isClosed) return;
@@ -31,10 +40,6 @@ abstract class Cubit<T> extends Stream<T> {
     _controller.add(state);
   }
 
-  /// Adds a subscription to the `Stream<T>`.
-  /// Returns a [StreamSubscription] which handles events from
-  /// the `Stream<T>` using the provided [onData], [onError] and [onDone]
-  /// handlers.
   @override
   StreamSubscription<T> listen(
     void Function(T) onData, {
@@ -50,11 +55,10 @@ abstract class Cubit<T> extends Stream<T> {
     );
   }
 
-  /// Returns whether the `Stream<T>` is a broadcast stream.
   @override
   bool get isBroadcast => _controller.stream.isBroadcast;
 
-  /// Closes the stream
+  /// Closes the stream.
   @mustCallSuper
   Future<void> close() async {
     await _controller.close();

--- a/packages/cubit/lib/src/cubit.dart
+++ b/packages/cubit/lib/src/cubit.dart
@@ -22,17 +22,13 @@ abstract class Cubit<T> extends Stream<T> {
 
   T _state;
 
-  /// Returns a `Future` which will completes when the cubit's
-  /// [state] has successfully been updated to the provided [state].
+  /// Updates the cubit's [state] to the provided [state].
+  /// If the `cubit` has been closed, emit will do nothing.
   @protected
-  Future<void> emit(T state) async {
-    // Wait one tick before updating the internal state.
-    // This ensures that the initial state has propagated.
-    return Future.delayed(Duration.zero, () {
-      if (_controller.isClosed) return;
-      _state = state;
-      _controller.add(state);
-    });
+  void emit(T state) async {
+    if (_controller.isClosed) return;
+    _state = state;
+    _controller.add(state);
   }
 
   /// Adds a subscription to the `Stream<T>`.
@@ -60,8 +56,9 @@ abstract class Cubit<T> extends Stream<T> {
 
   /// Closes the stream
   @mustCallSuper
-  Future<void> close() {
-    return Future.delayed(Duration.zero, _controller.close);
+  Future<void> close() async {
+    await _controller.close();
+    await _controller.stream.drain<T>();
   }
 
   Stream<T> get _stream async* {

--- a/packages/cubit/lib/src/cubit.dart
+++ b/packages/cubit/lib/src/cubit.dart
@@ -3,7 +3,7 @@ import 'dart:async';
 import 'package:meta/meta.dart';
 
 /// {@template cubit}
-/// A `cubit` is a reimagined `bloc` (from `package:bloc`)
+/// A `cubit` is a reimagined [bloc](https://pub.dev/packages/bloc)
 /// which removes events and relies on methods to emit new states instead.
 ///
 /// ```dart

--- a/packages/cubit/pubspec.yaml
+++ b/packages/cubit/pubspec.yaml
@@ -4,7 +4,7 @@ repository: https://github.com/felangel/cubit
 issue_tracker: https://github.com/felangel/cubit/issues
 homepage: https://github.com/felangel/cubit
 
-version: 0.0.1
+version: 0.0.2
 
 environment:
   sdk: ">=2.7.0 <3.0.0"
@@ -13,6 +13,5 @@ dependencies:
   meta: ^1.1.8
 
 dev_dependencies:
-  pedantic: ^1.9.0
   test: ^1.14.6
   test_coverage: ^0.4.1

--- a/packages/cubit/test/cubit_test.dart
+++ b/packages/cubit/test/cubit_test.dart
@@ -1,6 +1,5 @@
 import 'dart:async';
 
-import 'package:pedantic/pedantic.dart';
 import 'package:test/test.dart';
 
 import 'cubits/counter_cubit.dart';
@@ -22,40 +21,18 @@ void main() {
       test('does nothing if cubit is closed', () async {
         final cubit = CounterCubit();
         await cubit.close();
-        await cubit.increment();
+        cubit.increment();
         await expectLater(cubit, emitsInOrder(<Matcher>[equals(0), emitsDone]));
       });
 
-      test('emits states in the correct order async', () async {
-        final cubit = CounterCubit();
-        unawaited(expectLater(
-          cubit,
-          emitsInOrder(<Matcher>[
-            equals(0),
-            equals(1),
-            equals(0),
-            emitsDone,
-          ]),
-        ));
-        await cubit.increment();
-        await cubit.decrement();
+      test('emits states in the correct order', () async {
+        final states = <int>[];
+        final cubit = CounterCubit()
+          ..listen(states.add)
+          ..increment();
         await cubit.close();
-      });
-
-      test('emits states in the correct order sync', () async {
-        final cubit = CounterCubit();
-        unawaited(expectLater(
-          cubit,
-          emitsInOrder(<Matcher>[
-            equals(0),
-            equals(1),
-            equals(-1),
-            emitsDone,
-          ]),
-        ));
-        unawaited(cubit.increment());
-        unawaited(cubit.decrement());
-        await cubit.close();
+        await Future<void>.delayed(Duration.zero);
+        expect(states, [1]);
       });
     });
 

--- a/packages/cubit/test/cubits/counter_cubit.dart
+++ b/packages/cubit/test/cubits/counter_cubit.dart
@@ -4,6 +4,6 @@ class CounterCubit extends Cubit<int> {
   @override
   int get initialState => 0;
 
-  Future<void> increment() => emit(state + 1);
-  Future<void> decrement() => emit(state - 1);
+  void increment() => emit(state + 1);
+  void decrement() => emit(state - 1);
 }


### PR DESCRIPTION
- **BREAKING**: update `emit` to be a `void` function
- **BREAKING**: remove artifical wait to guarantee `initialState` is emitted
- **BREAKING**: `close` drains the internal `Stream`
- tests: 100% test coverage