### PR TITLE
feat!: cubit v0.0.3

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,8 +16,7 @@ A cubit is a reimagined bloc (from [package:bloc](https://pub.dev/packages/bloc)
 
 ```dart
 class CounterCubit extends Cubit<int> {
-  @override
-  int get initialState => 0;
+  CounterCubit() : super(0);
 
   void increment() => emit(state + 1);
   void decrement() => emit(state - 1);

--- a/packages/cubit/CHANGELOG.md
+++ b/packages/cubit/CHANGELOG.md
@@ -1,3 +1,7 @@
+# 0.0.3
+
+- **BREAKING**: remove `initialState` getter and instead require initial state via constructor
+
 # 0.0.2
 
 - **BREAKING**: update `emit` to be a `void` function

--- a/packages/cubit/README.md
+++ b/packages/cubit/README.md
@@ -12,8 +12,7 @@ An experimental Dart library which exposes a `cubit`. A cubit is a reimagined bl
 
 ```dart
 class CounterCubit extends Cubit<int> {
-  @override
-  int get initialState => 0;
+  CounterCubit() : super(0);
 
   void increment() => emit(state + 1);
 }

--- a/packages/cubit/example/main.dart
+++ b/packages/cubit/example/main.dart
@@ -8,8 +8,7 @@ void main() async {
 }
 
 class CounterCubit extends Cubit<int> {
-  @override
-  int get initialState => 0;
+  CounterCubit() : super(0);
 
   void increment() => emit(state + 1);
 }

--- a/packages/cubit/lib/src/cubit.dart
+++ b/packages/cubit/lib/src/cubit.dart
@@ -8,8 +8,7 @@ import 'package:meta/meta.dart';
 ///
 /// ```dart
 /// class CounterCubit extends Cubit<int> {
-///   @override
-///   int get initialState => 0;
+///   CounterCubit() : super(0);
 ///
 ///   void increment() => emit(state + 1);
 /// }
@@ -17,12 +16,7 @@ import 'package:meta/meta.dart';
 /// {@endtemplate}
 abstract class Cubit<T> extends Stream<T> {
   /// {@macro cubit}
-  Cubit() {
-    _state = initialState;
-  }
-
-  /// The initial [state] of the cubit.
-  T get initialState;
+  Cubit(this._state);
 
   /// The current [state] of the cubit
   T get state => _state;

--- a/packages/cubit/pubspec.yaml
+++ b/packages/cubit/pubspec.yaml
@@ -4,7 +4,7 @@ repository: https://github.com/felangel/cubit
 issue_tracker: https://github.com/felangel/cubit/issues
 homepage: https://github.com/felangel/cubit
 
-version: 0.0.2
+version: 0.0.3
 
 environment:
   sdk: ">=2.7.0 <3.0.0"

--- a/packages/cubit/test/cubit_test.dart
+++ b/packages/cubit/test/cubit_test.dart
@@ -6,13 +6,8 @@ import 'cubits/counter_cubit.dart';
 
 void main() {
   group('cubit', () {
-    group('initialState', () {
+    group('initial state', () {
       test('is correct', () {
-        expect(CounterCubit().initialState, 0);
-      });
-
-      test('state matches initialState', () {
-        expect(CounterCubit().initialState, 0);
         expect(CounterCubit().state, 0);
       });
     });

--- a/packages/cubit/test/cubits/counter_cubit.dart
+++ b/packages/cubit/test/cubits/counter_cubit.dart
@@ -1,8 +1,7 @@
 import 'package:cubit/cubit.dart';
 
 class CounterCubit extends Cubit<int> {
-  @override
-  int get initialState => 0;
+  CounterCubit() : super(0);
 
   void increment() => emit(state + 1);
   void decrement() => emit(state - 1);


### PR DESCRIPTION
- **BREAKING**: remove `initialState` getter and instead require initial state via constructor