### PR TITLE
fix: hide CubitListenerSingleChildWidget and CubitProviderSingleChildWidget

### DIFF
--- a/packages/flutter_cubit/CHANGELOG.md
+++ b/packages/flutter_cubit/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 - fix: hide `CubitListenerSingleChildWidget`
 - fix: hide `CubitProviderSingleChildWidget`
+- fix: `ProviderNotFoundException` handling
+- fix: do not leak `Provider` implementation
 
 # 0.0.4
 

--- a/packages/flutter_cubit/CHANGELOG.md
+++ b/packages/flutter_cubit/CHANGELOG.md
@@ -1,3 +1,8 @@
+# 0.0.5
+
+- fix: hide `CubitListenerSingleChildWidget`
+- fix: hide `CubitProviderSingleChildWidget`
+
 # 0.0.4
 
 - feat: add `CubitConsumer`

--- a/packages/flutter_cubit/lib/flutter_cubit.dart
+++ b/packages/flutter_cubit/lib/flutter_cubit.dart
@@ -2,7 +2,7 @@ library flutter_cubit;
 
 export 'src/cubit_builder.dart';
 export 'src/cubit_consumer.dart';
-export 'src/cubit_listener.dart';
-export 'src/cubit_provider.dart';
+export 'src/cubit_listener.dart' hide CubitListenerSingleChildWidget;
+export 'src/cubit_provider.dart' hide CubitProviderSingleChildWidget;
 export 'src/multi_cubit_listener.dart';
 export 'src/multi_cubit_provider.dart';

--- a/packages/flutter_cubit/lib/src/cubit_provider.dart
+++ b/packages/flutter_cubit/lib/src/cubit_provider.dart
@@ -4,6 +4,11 @@ import 'package:cubit/cubit.dart';
 import 'package:provider/provider.dart';
 import 'package:provider/single_child_widget.dart';
 
+/// A function that creates a `Cubit` of type [T].
+typedef CreateCubit<T extends Cubit<dynamic>> = T Function(
+  BuildContext context,
+);
+
 /// Mixin which allows `MultiCubitProvider` to infer the types
 /// of multiple [CubitProvider]s.
 mixin CubitProviderSingleChildWidget on SingleChildWidget {}
@@ -30,7 +35,7 @@ class CubitProvider<T extends Cubit<dynamic>> extends SingleChildStatelessWidget
   /// {@macro cubitprovider}
   CubitProvider({
     Key key,
-    @required Create<T> create,
+    @required CreateCubit<T> create,
     Widget child,
     bool lazy,
   }) : this._(
@@ -103,7 +108,8 @@ class CubitProvider<T extends Cubit<dynamic>> extends SingleChildStatelessWidget
   static T of<T extends Cubit<dynamic>>(BuildContext context) {
     try {
       return Provider.of<T>(context, listen: false);
-    } on ProviderNotFoundException catch (_) {
+    } on ProviderNotFoundException catch (e) {
+      if (e.valueType != T) rethrow;
       throw FlutterError(
         '''
         CubitProvider.of() called with a context that does not contain a Cubit of type $T.

--- a/packages/flutter_cubit/pubspec.yaml
+++ b/packages/flutter_cubit/pubspec.yaml
@@ -4,7 +4,7 @@ repository: https://github.com/felangel/cubit
 issue_tracker: https://github.com/felangel/cubit/issues
 homepage: https://github.com/felangel/cubit
 
-version: 0.0.4
+version: 0.0.5
 
 environment:
   sdk: ">=2.7.0 <3.0.0"

--- a/packages/flutter_cubit/test/cubit_provider_test.dart
+++ b/packages/flutter_cubit/test/cubit_provider_test.dart
@@ -5,6 +5,7 @@ import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
 
 import 'package:flutter_cubit/flutter_cubit.dart';
+import 'package:provider/provider.dart';
 
 class MyApp extends StatelessWidget {
   const MyApp({
@@ -373,6 +374,20 @@ void main() {
 ''';
       expect(exception is FlutterError, true);
       expect(exception.message, expectedMessage);
+    });
+
+    testWidgets(
+        'should not wrap into FlutterError if '
+        'ProviderNotFoundException with wrong valueType '
+        'is thrown', (tester) async {
+      await tester.pumpWidget(
+        CubitProvider<CounterCubit>(
+          create: (context) => CounterCubit(onClose: Provider.of(context)),
+          child: const CounterPage(),
+        ),
+      );
+      final dynamic exception = tester.takeException();
+      expect(exception is ProviderNotFoundException, true);
     });
 
     testWidgets(


### PR DESCRIPTION
- fix: hide `CubitListenerSingleChildWidget`
- fix: hide `CubitProviderSingleChildWidget`
- fix: `ProviderNotFoundException` handling
- fix: do not leak `Provider` implementation