### PR TITLE
refactor!: make cubit initial state a named parameter

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ A cubit is a reimagined bloc (from [package:bloc](https://pub.dev/packages/bloc)
 
 ```dart
 class CounterCubit extends Cubit<int> {
-  CounterCubit() : super(0);
+  CounterCubit() : super(initialState: 0);
 
   void increment() => emit(state + 1);
   void decrement() => emit(state - 1);

--- a/packages/cubit/CHANGELOG.md
+++ b/packages/cubit/CHANGELOG.md
@@ -1,3 +1,7 @@
+# 0.0.4
+
+- **BREAKING**: use named parameter for `initialState`
+
 # 0.0.3
 
 - **BREAKING**: remove `initialState` getter and instead require initial state via constructor

--- a/packages/cubit/README.md
+++ b/packages/cubit/README.md
@@ -12,7 +12,7 @@ An experimental Dart library which exposes a `cubit`. A cubit is a reimagined bl
 
 ```dart
 class CounterCubit extends Cubit<int> {
-  CounterCubit() : super(0);
+  CounterCubit() : super(initialState: 0);
 
   void increment() => emit(state + 1);
 }

--- a/packages/cubit/example/main.dart
+++ b/packages/cubit/example/main.dart
@@ -8,7 +8,7 @@ void main() async {
 }
 
 class CounterCubit extends Cubit<int> {
-  CounterCubit() : super(0);
+  CounterCubit() : super(initialState: 0);
 
   void increment() => emit(state + 1);
 }

--- a/packages/cubit/lib/src/cubit.dart
+++ b/packages/cubit/lib/src/cubit.dart
@@ -8,7 +8,7 @@ import 'package:meta/meta.dart';
 ///
 /// ```dart
 /// class CounterCubit extends Cubit<int> {
-///   CounterCubit() : super(0);
+///   CounterCubit() : super(initialState: 0);
 ///
 ///   void increment() => emit(state + 1);
 /// }
@@ -16,7 +16,9 @@ import 'package:meta/meta.dart';
 /// {@endtemplate}
 abstract class Cubit<T> extends Stream<T> {
   /// {@macro cubit}
-  Cubit(this._state);
+  Cubit({@required T initialState})
+      : assert(initialState != null),
+        _state = initialState;
 
   /// The current [state] of the cubit.
   T get state => _state;

--- a/packages/cubit/pubspec.yaml
+++ b/packages/cubit/pubspec.yaml
@@ -4,7 +4,7 @@ repository: https://github.com/felangel/cubit
 issue_tracker: https://github.com/felangel/cubit/issues
 homepage: https://github.com/felangel/cubit
 
-version: 0.0.3
+version: 0.0.4
 
 environment:
   sdk: ">=2.7.0 <3.0.0"

--- a/packages/cubit/test/cubit_test.dart
+++ b/packages/cubit/test/cubit_test.dart
@@ -2,10 +2,17 @@ import 'dart:async';
 
 import 'package:test/test.dart';
 
-import 'cubits/counter_cubit.dart';
+import 'cubits/cubits.dart';
 
 void main() {
   group('cubit', () {
+    test('throws AssertionError if initialState is null', () {
+      expect(
+        () => SeededCubit(initialState: null),
+        throwsA(isA<AssertionError>()),
+      );
+    });
+
     group('initial state', () {
       test('is correct', () {
         expect(CounterCubit().state, 0);

--- a/packages/cubit/test/cubits/counter_cubit.dart
+++ b/packages/cubit/test/cubits/counter_cubit.dart
@@ -1,7 +1,7 @@
 import 'package:cubit/cubit.dart';
 
 class CounterCubit extends Cubit<int> {
-  CounterCubit() : super(0);
+  CounterCubit() : super(initialState: 0);
 
   void increment() => emit(state + 1);
   void decrement() => emit(state - 1);

--- a/packages/cubit/test/cubits/cubits.dart
+++ b/packages/cubit/test/cubits/cubits.dart
@@ -1,0 +1,2 @@
+export 'counter_cubit.dart';
+export 'seeded_cubit.dart';

--- a/packages/cubit/test/cubits/seeded_cubit.dart
+++ b/packages/cubit/test/cubits/seeded_cubit.dart
@@ -1,0 +1,5 @@
+import 'package:cubit/cubit.dart';
+
+class SeededCubit<T> extends Cubit<T> {
+  SeededCubit({T initialState}) : super(initialState: initialState);
+}


### PR DESCRIPTION
- **BREAKING**: use named parameter for `initialState`

#### Before

```dart
import 'package:cubit/cubit.dart';

class CounterCubit extends Cubit<int> {
  CounterCubit() : super(0);

  void increment() => emit(state + 1);
}
```

#### After

```dart
import 'package:cubit/cubit.dart';

class CounterCubit extends Cubit<int> {
  CounterCubit() : super(initialState: 0);

  void increment() => emit(state + 1);
}
```