### PR TITLE
Clean up README files

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,24 +1,16 @@
-<img src="https://raw.githubusercontent.com/felangel/cubit/master/assets/cubit_full.png" height="150" alt="Cubit" />
+<p align="center"><img src="https://raw.githubusercontent.com/felangel/cubit/master/assets/cubit_full.png" height="100" alt="Cubit"></p>
 
-[![build](https://github.com/felangel/cubit/workflows/build/badge.svg)](https://github.com/felangel/cubit/actions)
-[![coverage](https://github.com/felangel/cubit/blob/master/packages/cubit/coverage_badge.svg)](https://github.com/felangel/cubit/actions)
-[![Star on GitHub](https://img.shields.io/github/stars/felangel/cubit.svg?style=flat&logo=github&colorB=deeppink&label=stars)](https://github.com/felangel/cubit)
-[![License: MIT](https://img.shields.io/badge/license-MIT-purple.svg)](https://opensource.org/licenses/MIT)
+<p align="center">
+<a href="https://github.com/felangel/cubit/actions"><img src="https://github.com/felangel/cubit/workflows/build/badge.svg" alt="build"></a>
+<a href="https://github.com/felangel/cubit/actions"><img src="https://github.com/felangel/cubit/blob/master/packages/cubit/coverage_badge.svg" alt="coverage"></a>
+<a href="https://github.com/felangel/cubit"><img src="https://img.shields.io/github/stars/felangel/cubit.svg?style=flat&logo=github&colorB=deeppink&label=stars" alt="Star on GitHub"></a>
+<a href="https://opensource.org/licenses/MIT"><img src="https://img.shields.io/badge/license-MIT-purple.svg" alt="License: MIT"></a>
+<a href="https://github.com/zepfietje/starware"><img src="https://img.shields.io/badge/Starware-%E2%AD%90-black?labelColor=%23f9b00d" alt="Starware"></a>
+</p>
 
----
+Cubit is a lightweight state management solution. It is a subset of the [bloc package](https://pub.dev/packages/bloc) that does not rely on events and instead uses methods to emit new states.
 
-**WARNING: This is highly experimental**
-
-`Cubit` is a lightweight state management solution. It is a subset of the [bloc package](https://pub.dev/packages/bloc) that does not rely on events and instead uses methods to emit new states.
-
-| Package                                                                               | Pub                                                                                                      |
-| ------------------------------------------------------------------------------------- | -------------------------------------------------------------------------------------------------------- |
-| [cubit](https://github.com/felangel/cubit/tree/master/packages/cubit)                 | [![pub package](https://img.shields.io/pub/v/cubit.svg)](https://pub.dev/packages/cubit)                 |
-| [cubit_test](https://github.com/felangel/cubit/tree/master/packages/cubit_test)       | [![pub package](https://img.shields.io/pub/v/cubit_test.svg)](https://pub.dev/packages/cubit_test)       |
-| [flutter_cubit](https://github.com/felangel/cubit/tree/master/packages/flutter_cubit) | [![pub package](https://img.shields.io/pub/v/flutter_cubit.svg)](https://pub.dev/packages/flutter_cubit) |
-| [angular_cubit](https://github.com/felangel/cubit/tree/master/packages/angular_cubit) | [![pub package](https://img.shields.io/pub/v/angular_cubit.svg)](https://pub.dev/packages/angular_cubit) |
-
-## Overview
+## Usage
 
 ```dart
 class CounterCubit extends Cubit<int> {
@@ -28,6 +20,15 @@ class CounterCubit extends Cubit<int> {
   void decrement() => emit(state - 1);
 }
 ```
+
+## Packages
+
+| Package                                                                               | Pub                                                                                                      |
+| ------------------------------------------------------------------------------------- | -------------------------------------------------------------------------------------------------------- |
+| [cubit](https://github.com/felangel/cubit/tree/master/packages/cubit)                 | [![pub package](https://img.shields.io/pub/v/cubit.svg)](https://pub.dev/packages/cubit)                 |
+| [cubit_test](https://github.com/felangel/cubit/tree/master/packages/cubit_test)       | [![pub package](https://img.shields.io/pub/v/cubit_test.svg)](https://pub.dev/packages/cubit_test)       |
+| [flutter_cubit](https://github.com/felangel/cubit/tree/master/packages/flutter_cubit) | [![pub package](https://img.shields.io/pub/v/flutter_cubit.svg)](https://pub.dev/packages/flutter_cubit) |
+| [angular_cubit](https://github.com/felangel/cubit/tree/master/packages/angular_cubit) | [![pub package](https://img.shields.io/pub/v/angular_cubit.svg)](https://pub.dev/packages/angular_cubit) |
 
 ## Documentation
 
@@ -40,6 +41,12 @@ class CounterCubit extends Cubit<int> {
 
 - Dart 2: >= 2.7.0
 
-### Maintainers
+## Maintainers
 
 - [Felix Angelov](https://github.com/felangel)
+
+## Starware
+
+Cubit is Starware.  
+This means you're free to use the project, as long as you star its GitHub repository.  
+Your appreciation makes us grow and glow up. ⭐

--- a/packages/angular_cubit/README.md
+++ b/packages/angular_cubit/README.md
@@ -1,14 +1,13 @@
-<img src="https://raw.githubusercontent.com/felangel/cubit/master/assets/angular_cubit_full.png" height="150" alt="Angular Cubit" />
+<p align="center"><img src="https://raw.githubusercontent.com/felangel/cubit/master/assets/angular_cubit_full.png" height="100" alt="Angular Cubit"></p>
 
-[![Pub](https://img.shields.io/pub/v/angular_cubit.svg)](https://pub.dev/packages/angular_cubit)
-[![build](https://github.com/felangel/cubit/workflows/build/badge.svg)](https://github.com/felangel/cubit/actions)
-[![coverage](https://github.com/felangel/cubit/blob/master/packages/angular_cubit/coverage_badge.svg)](https://github.com/felangel/cubit/actions)
-[![Star on GitHub](https://img.shields.io/github/stars/felangel/cubit.svg?style=flat&logo=github&colorB=deeppink&label=stars)](https://github.com/felangel/cubit)
-[![License: MIT](https://img.shields.io/badge/license-MIT-purple.svg)](https://opensource.org/licenses/MIT)
-
----
-
-**WARNING: This is highly experimental**
+<p align="center">
+<a href="https://pub.dev/packages/angular_cubit"><img src="https://img.shields.io/pub/v/angular_cubit.svg" alt="Pub"></a>
+<a href="https://github.com/felangel/cubit/actions"><img src="https://github.com/felangel/cubit/workflows/build/badge.svg" alt="build"></a>
+<a href="https://github.com/felangel/cubit/actions"><img src="https://github.com/felangel/cubit/blob/master/packages/angular_cubit/coverage_badge.svg" alt="coverage"></a>
+<a href="https://github.com/felangel/cubit"><img src="https://img.shields.io/github/stars/felangel/cubit.svg?style=flat&logo=github&colorB=deeppink&label=stars" alt="Star on GitHub"></a>
+<a href="https://opensource.org/licenses/MIT"><img src="https://img.shields.io/badge/license-MIT-purple.svg" alt="License: MIT"></a>
+<a href="https://github.com/zepfietje/starware"><img src="https://img.shields.io/badge/Starware-%E2%AD%90-black?labelColor=%23f9b00d" alt="Starware"></a>
+</p>
 
 An AngularDart library built to expose components that integrate with cubits. Built to work with the [cubit](https://pub.dev/packages/cubit) and [bloc](https://pub.dev/packages/bloc) state management packages.
 
@@ -76,6 +75,12 @@ At this point we have successfully separated our presentational layer from our b
 
 - Dart 2: >= 2.7.0
 
-### Maintainers
+## Maintainers
 
 - [Felix Angelov](https://github.com/felangel)
+
+## Starware
+
+Angular Cubit is Starware.  
+This means you're free to use the project, as long as you star its GitHub repository.  
+Your appreciation makes us grow and glow up. ⭐

--- a/packages/cubit/README.md
+++ b/packages/cubit/README.md
@@ -1,16 +1,15 @@
-<img src="https://raw.githubusercontent.com/felangel/cubit/master/assets/cubit_full.png" height="150" alt="Cubit" />
+<p align="center"><img src="https://raw.githubusercontent.com/felangel/cubit/master/assets/cubit_full.png" height="100" alt="Cubit"></p>
 
-[![Pub](https://img.shields.io/pub/v/cubit.svg)](https://pub.dev/packages/cubit)
-[![build](https://github.com/felangel/cubit/workflows/build/badge.svg)](https://github.com/felangel/cubit/actions)
-[![coverage](https://github.com/felangel/cubit/blob/master/packages/cubit/coverage_badge.svg)](https://github.com/felangel/cubit/actions)
-[![Star on GitHub](https://img.shields.io/github/stars/felangel/cubit.svg?style=flat&logo=github&colorB=deeppink&label=stars)](https://github.com/felangel/cubit)
-[![License: MIT](https://img.shields.io/badge/license-MIT-purple.svg)](https://opensource.org/licenses/MIT)
+<p align="center">
+<a href="https://pub.dev/packages/cubit"><img src="https://img.shields.io/pub/v/cubit.svg" alt="Pub"></a>
+<a href="https://github.com/felangel/cubit/actions"><img src="https://github.com/felangel/cubit/workflows/build/badge.svg" alt="build"></a>
+<a href="https://github.com/felangel/cubit/actions"><img src="https://github.com/felangel/cubit/blob/master/packages/cubit/coverage_badge.svg" alt="coverage"></a>
+<a href="https://github.com/felangel/cubit"><img src="https://img.shields.io/github/stars/felangel/cubit.svg?style=flat&logo=github&colorB=deeppink&label=stars" alt="Star on GitHub"></a>
+<a href="https://opensource.org/licenses/MIT"><img src="https://img.shields.io/badge/license-MIT-purple.svg" alt="License: MIT"></a>
+<a href="https://github.com/zepfietje/starware"><img src="https://img.shields.io/badge/Starware-%E2%AD%90-black?labelColor=%23f9b00d" alt="Starware"></a>
+</p>
 
----
-
-**WARNING: This is highly experimental**
-
-`Cubit` is a lightweight state management solution. It is a subset of the [bloc package](https://pub.dev/packages/bloc) that does not rely on events and instead uses methods to emit new states.
+Cubit is a lightweight state management solution. It is a subset of the [bloc package](https://pub.dev/packages/bloc) that does not rely on events and instead uses methods to emit new states.
 
 Every `cubit` requires an initial state which will be the state of the `cubit` before `emit` has been called.
 The current state of a `cubit` can be accessed via the `state` getter.
@@ -38,6 +37,12 @@ void main() async {
 
 - Dart 2: >= 2.7.0
 
-### Maintainers
+## Maintainers
 
 - [Felix Angelov](https://github.com/felangel)
+
+## Starware
+
+Cubit is Starware.  
+This means you're free to use the project, as long as you star its GitHub repository.  
+Your appreciation makes us grow and glow up. ⭐

--- a/packages/cubit_test/README.md
+++ b/packages/cubit_test/README.md
@@ -1,14 +1,13 @@
-<img src="https://raw.githubusercontent.com/felangel/cubit/master/assets/cubit_test_full.png" height="150" alt="Cubit Test" />
+<p align="center"><img src="https://raw.githubusercontent.com/felangel/cubit/master/assets/cubit_test_full.png" height="100" alt="Cubit Test"></p>
 
-[![Pub](https://img.shields.io/pub/v/cubit_test.svg)](https://pub.dev/packages/cubit_test)
-[![build](https://github.com/felangel/cubit/workflows/build/badge.svg)](https://github.com/felangel/cubit/actions)
-[![coverage](https://github.com/felangel/cubit/blob/master/packages/cubit_test/coverage_badge.svg)](https://github.com/felangel/cubit/actions)
-[![Star on GitHub](https://img.shields.io/github/stars/felangel/cubit.svg?style=flat&logo=github&colorB=deeppink&label=stars)](https://github.com/felangel/cubit)
-[![License: MIT](https://img.shields.io/badge/license-MIT-purple.svg)](https://opensource.org/licenses/MIT)
-
----
-
-**WARNING: This is highly experimental**
+<p align="center">
+<a href="https://pub.dev/packages/cubit_test"><img src="https://img.shields.io/pub/v/cubit_test.svg" alt="Pub"></a>
+<a href="https://github.com/felangel/cubit/actions"><img src="https://github.com/felangel/cubit/workflows/build/badge.svg" alt="build"></a>
+<a href="https://github.com/felangel/cubit/actions"><img src="https://github.com/felangel/cubit/blob/master/packages/cubit_test/coverage_badge.svg" alt="coverage"></a>
+<a href="https://github.com/felangel/cubit"><img src="https://img.shields.io/github/stars/felangel/cubit.svg?style=flat&logo=github&colorB=deeppink&label=stars" alt="Star on GitHub"></a>
+<a href="https://opensource.org/licenses/MIT"><img src="https://img.shields.io/badge/license-MIT-purple.svg" alt="License: MIT"></a>
+<a href="https://github.com/zepfietje/starware"><img src="https://img.shields.io/badge/Starware-%E2%AD%90-black?labelColor=%23f9b00d" alt="Starware"></a>
+</p>
 
 A Dart package built to make testing cubits easy. Built to work with the [cubit](https://pub.dev/packages/cubit) and [bloc](https://pub.dev/packages/bloc) state management packages.
 
@@ -127,3 +126,9 @@ cubitTest(
 ## Maintainers
 
 - [Felix Angelov](https://github.com/felangel)
+
+## Starware
+
+Cubit Test is Starware.  
+This means you're free to use the project, as long as you star its GitHub repository.  
+Your appreciation makes us grow and glow up. ⭐

--- a/packages/flutter_cubit/README.md
+++ b/packages/flutter_cubit/README.md
@@ -1,22 +1,21 @@
-<img src="https://raw.githubusercontent.com/felangel/cubit/master/assets/flutter_cubit_full.png" height="150" alt="Flutter Cubit" />
+<p align="center"><img src="https://raw.githubusercontent.com/felangel/cubit/master/assets/flutter_cubit_full.png" height="100" alt="Flutter Cubit"></p>
 
-[![Pub](https://img.shields.io/pub/v/flutter_cubit.svg)](https://pub.dev/packages/flutter_cubit)
-[![build](https://github.com/felangel/cubit/workflows/build/badge.svg)](https://github.com/felangel/cubit/actions)
-[![coverage](https://github.com/felangel/cubit/blob/master/packages/cubit/coverage_badge.svg)](https://github.com/felangel/cubit/actions)
-[![Star on GitHub](https://img.shields.io/github/stars/felangel/cubit.svg?style=flat&logo=github&colorB=deeppink&label=stars)](https://github.com/felangel/cubit)
-[![License: MIT](https://img.shields.io/badge/license-MIT-purple.svg)](https://opensource.org/licenses/MIT)
-
----
-
-**WARNING: This is highly experimental**
+<p align="center">
+<a href="https://pub.dev/packages/flutter_cubit"><img src="https://img.shields.io/pub/v/flutter_cubit.svg" alt="Pub"></a>
+<a href="https://github.com/felangel/cubit/actions"><img src="https://github.com/felangel/cubit/workflows/build/badge.svg" alt="build"></a>
+<a href="https://github.com/felangel/cubit/actions"><img src="https://github.com/felangel/cubit/blob/master/packages/flutter_cubit/coverage_badge.svg" alt="coverage"></a>
+<a href="https://github.com/felangel/cubit"><img src="https://img.shields.io/github/stars/felangel/cubit.svg?style=flat&logo=github&colorB=deeppink&label=stars" alt="Star on GitHub"></a>
+<a href="https://opensource.org/licenses/MIT"><img src="https://img.shields.io/badge/license-MIT-purple.svg" alt="License: MIT"></a>
+<a href="https://github.com/zepfietje/starware"><img src="https://img.shields.io/badge/Starware-%E2%AD%90-black?labelColor=%23f9b00d" alt="Starware"></a>
+</p>
 
 A Flutter library built to expose widgets that integrate with cubits. Built to work with the [cubit](https://pub.dev/packages/cubit) and [bloc](https://pub.dev/packages/bloc) state management packages.
 
 ## Usage
 
-Lets take a look at how to use `CubitBuilder` to hook up a `CounterPage` widget to a `CounterCubit`.
+Let's take a look at how to use `CubitBuilder` to hook up a `CounterPage` widget to a `CounterCubit`.
 
-### counter_cubit.dart
+### `counter_cubit.dart`
 
 ```dart
 class CounterCubit extends Cubit<int> {
@@ -27,7 +26,7 @@ class CounterCubit extends Cubit<int> {
 }
 ```
 
-### main.dart
+### `main.dart`
 
 ```dart
 void main() => runApp(CubitCounter());
@@ -306,6 +305,12 @@ CubitConsumer<CubitA, CubitAState>(
 
 - Dart 2: >= 2.7.0
 
-### Maintainers
+## Maintainers
 
 - [Felix Angelov](https://github.com/felangel)
+
+## Starware
+
+Flutter Cubit is Starware.  
+This means you're free to use the project, as long as you star its GitHub repository.  
+Your appreciation makes us grow and glow up. ⭐


### PR DESCRIPTION
- Fixed some typos.
- Made README headers look friendlier.
- Removed warnings (cubit will soon be used in production, e.g. with bloc).
- Added [Starware](https://github.com/zepfietje/starware) info. Starware is a semiserious type of license that encourages users to show appreciation to project maintainers and, in doing so, boost the package's popularity. Great for Cubit!