### PR TITLE
feat(cubit): add CubitObserver

### DIFF
--- a/packages/cubit/CHANGELOG.md
+++ b/packages/cubit/CHANGELOG.md
@@ -1,3 +1,8 @@
+# 0.0.14
+
+- feat: add `CubitObserver` support
+- docs: minor documentation improvements
+
 # 0.0.13
 
 - docs: various documentation updates

--- a/packages/cubit/README.md
+++ b/packages/cubit/README.md
@@ -24,7 +24,7 @@ class CounterCubit extends Cubit<int> {
 }
 ```
 
-## Consuming a Cubit
+## Using a Cubit
 
 ```dart
 void main() async {

--- a/packages/cubit/example/main.dart
+++ b/packages/cubit/example/main.dart
@@ -1,6 +1,15 @@
 import 'package:cubit/cubit.dart';
 
+class MyCubitObserver extends CubitObserver {
+  @override
+  void onTransition(Cubit cubit, Transition transition) {
+    print(transition);
+    super.onTransition(cubit, transition);
+  }
+}
+
 void main() async {
+  Cubit.observer = CubitObserver();
   final cubit = CounterCubit()..increment();
   await cubit.close();
 }
@@ -9,10 +18,4 @@ class CounterCubit extends Cubit<int> {
   CounterCubit() : super(0);
 
   void increment() => emit(state + 1);
-
-  @override
-  void onTransition(Transition<int> transition) {
-    print(transition);
-    super.onTransition(transition);
-  }
 }

--- a/packages/cubit/example/main.dart
+++ b/packages/cubit/example/main.dart
@@ -9,7 +9,7 @@ class MyCubitObserver extends CubitObserver {
 }
 
 void main() async {
-  Cubit.observer = CubitObserver();
+  Cubit.observer = MyCubitObserver();
   final cubit = CounterCubit()..increment();
   await cubit.close();
 }

--- a/packages/cubit/lib/cubit.dart
+++ b/packages/cubit/lib/cubit.dart
@@ -1,5 +1,6 @@
 library cubit;
 
 export 'src/cubit.dart';
+export 'src/cubit_observer.dart';
 export 'src/cubit_stream.dart';
 export 'src/transition.dart';

--- a/packages/cubit/lib/src/cubit.dart
+++ b/packages/cubit/lib/src/cubit.dart
@@ -1,3 +1,4 @@
+import 'package:cubit/cubit.dart';
 import 'package:meta/meta.dart';
 
 import 'cubit_stream.dart';
@@ -30,6 +31,9 @@ abstract class Cubit<State> extends CubitStream<State> {
   /// {@macro cubit}
   Cubit(State initialState) : super(initialState);
 
+  /// The current [CubitObserver].
+  static CubitObserver observer = CubitObserver();
+
   /// Called whenever a [transition] occurs with the given [transition].
   /// A [transition] occurs when a new `state` is emitted.
   /// [onTransition] is called before the `state` of the `cubit` is updated.
@@ -45,8 +49,14 @@ abstract class Cubit<State> extends CubitStream<State> {
   ///   super.onTransition(transition);
   /// }
   /// ```
+  ///
+  /// See also:
+  ///
+  /// * [CubitObserver] for observing [Cubit] behavior globally.
   @mustCallSuper
-  void onTransition(Transition<State> transition) {}
+  void onTransition(Transition<State> transition) {
+    observer.onTransition(this, transition);
+  }
 
   /// {@macro emit}
   @override

--- a/packages/cubit/lib/src/cubit_observer.dart
+++ b/packages/cubit/lib/src/cubit_observer.dart
@@ -1,0 +1,13 @@
+import 'package:meta/meta.dart';
+
+import '../cubit.dart';
+
+/// An interface for observing the behavior of a [Cubit].
+class CubitObserver {
+  /// Called whenever a transition occurs in any [cubit] with the given [cubit]
+  /// and [transition].
+  /// A [transition] occurs when a new state is emitted.
+  /// [onTransition] is called before a cubit's state has been updated.
+  @mustCallSuper
+  void onTransition(Cubit cubit, Transition transition) {}
+}

--- a/packages/cubit/pubspec.yaml
+++ b/packages/cubit/pubspec.yaml
@@ -4,7 +4,7 @@ repository: https://github.com/felangel/cubit
 issue_tracker: https://github.com/felangel/cubit/issues
 homepage: https://github.com/felangel/cubit
 
-version: 0.0.13
+version: 0.0.14
 
 environment:
   sdk: ">=2.7.0 <3.0.0"
@@ -13,5 +13,6 @@ dependencies:
   meta: ^1.1.8
 
 dev_dependencies:
+  mockito: ^4.1.1
   test: ^1.14.6
   test_coverage: ^0.4.1

--- a/packages/cubit/test/cubit_observer_test.dart
+++ b/packages/cubit/test/cubit_observer_test.dart
@@ -1,0 +1,18 @@
+import 'package:cubit/cubit.dart';
+import 'package:mockito/mockito.dart';
+import 'package:test/test.dart';
+
+class MockCubit extends Mock implements Cubit<int> {}
+
+// ignore: must_be_immutable
+class MockTransition extends Mock implements Transition<int> {}
+
+void main() {
+  group('CubitObserver', () {
+    group('onTransition', () {
+      test('does nothing by default', () {
+        CubitObserver().onTransition(MockCubit(), MockTransition());
+      });
+    });
+  });
+}


### PR DESCRIPTION
- feat: add `CubitObserver` support
- docs: minor documentation improvements

```dart
class MyCubitObserver extends CubitObserver {
  @override
  void onTransition(Cubit cubit, Transition transition) {
    print(transition);
    super.onTransition(cubit, transition);
  }
}

void main() async {
  Cubit.observer = MyCubitObserver();
  ...
}
```