### PR TITLE
feat(hydrated_cubit)!: v0.0.3

### DIFF
--- a/packages/hydrated_cubit/CHANGELOG.md
+++ b/packages/hydrated_cubit/CHANGELOG.md
@@ -1,3 +1,10 @@
+# 0.0.3
+
+- **BREAKING**:
+  - Rename `HydratedStorage` to `Storage`
+  - Rename `HydratedCubitStorage` to `HydratedStorage`
+  - Rename `getInstance` to `build`
+
 # 0.0.2
 
 - docs: minor improvements to README

--- a/packages/hydrated_cubit/README.md
+++ b/packages/hydrated_cubit/README.md
@@ -33,7 +33,7 @@ class CounterCubit extends HydratedCubit<int> {
 ```dart
 void main() async {
   WidgetsFlutterBinding.ensureInitialized();
-  HydratedCubit.storage = await HydratedCubitStorage.getInstance();
+  HydratedCubit.storage = await HydratedStorage.build();
   final counterCubit = CounterCubit();
 }
 ```

--- a/packages/hydrated_cubit/example/lib/main.dart
+++ b/packages/hydrated_cubit/example/lib/main.dart
@@ -5,7 +5,7 @@ import 'package:hydrated_cubit/hydrated_cubit.dart';
 
 void main() async {
   WidgetsFlutterBinding.ensureInitialized();
-  HydratedCubit.storage = await HydratedCubitStorage.getInstance();
+  HydratedCubit.storage = await HydratedStorage.build();
   runApp(App());
 }
 

--- a/packages/hydrated_cubit/lib/src/hydrated_cubit.dart
+++ b/packages/hydrated_cubit/lib/src/hydrated_cubit.dart
@@ -12,7 +12,7 @@ import 'hydrated_storage.dart';
 /// ```dart
 /// void main() async {
 ///   WidgetsFlutterBinding.ensureInitialized();
-///   HydratedCubit.storage = await HydratedCubitStorage.getInstance();
+///   HydratedCubit.storage = await HydratedStorage.build();
 ///   runApp(MyApp());
 /// }
 /// ```
@@ -27,7 +27,7 @@ class HydratedStorageNotFound implements Exception {
     return 'HydratedStorage was accessed before it was initialized.\n'
         'Please ensure that storage has been initialized.\n\n'
         'For example:\n\n'
-        'HydratedCubit.storage = await HydratedCubitStorage.getInstance();';
+        'HydratedCubit.storage = await HydratedStorage.build();';
   }
 }
 
@@ -48,9 +48,9 @@ abstract class HydratedCubit<State> extends Cubit<State> {
     }
   }
 
-  /// Instance of [HydratedStorage] which will be used to
+  /// Instance of [Storage] which will be used to
   /// manage persisting/restoring the [Cubit] state.
-  static HydratedStorage storage;
+  static Storage storage;
 
   State _state;
 

--- a/packages/hydrated_cubit/lib/src/hydrated_storage.dart
+++ b/packages/hydrated_cubit/lib/src/hydrated_storage.dart
@@ -7,9 +7,8 @@ import 'package:synchronized/synchronized.dart';
 
 import 'hydrated_cipher.dart';
 
-/// Interface which `HydratedCubitDelegate` uses to persist and retrieve
-/// state changes from the local device.
-abstract class HydratedStorage {
+/// Interface which is used to persist and retrieve state changes.
+abstract class Storage {
   /// Returns value for key
   dynamic read(String key);
 
@@ -24,17 +23,17 @@ abstract class HydratedStorage {
 }
 
 /// {@template hydrated_cubit_storage}
-/// Implementation of [HydratedStorage] which uses `PathProvider` and `dart.io`
+/// Implementation of [Storage] which uses `PathProvider` and `dart.io`
 /// to persist and retrieve state changes from the local device.
 /// {@endtemplate}
-class HydratedCubitStorage extends HydratedStorage {
+class HydratedStorage implements Storage {
   /// {@macro hydrated_cubit_storage}
   @visibleForTesting
-  HydratedCubitStorage(this._box);
+  HydratedStorage(this._box);
 
-  /// Returns an instance of `HydratedCubitStorage`.
+  /// Returns an instance of [HydratedStorage].
   /// [storageDirectory] can optionally be provided.
-  /// By default, `getTemporaryDirectory` is used.
+  /// By default, [getTemporaryDirectory] is used.
   ///
   /// With [encryptionCipher] you can provide custom encryption.
   /// Following snippet shows how to make default one:
@@ -46,7 +45,7 @@ class HydratedCubitStorage extends HydratedStorage {
   /// final byteskey = sha256.convert(utf8.encode(password)).bytes;
   /// return HydratedAesCipher(byteskey);
   /// ```
-  static Future<HydratedStorage> getInstance({
+  static Future<HydratedStorage> build({
     Directory storageDirectory,
     HydratedCipher encryptionCipher,
   }) {
@@ -58,7 +57,7 @@ class HydratedCubitStorage extends HydratedStorage {
         'hydrated_box',
         encryptionCipher: encryptionCipher,
       );
-      return _instance = HydratedCubitStorage(box);
+      return _instance = HydratedStorage(box);
     });
   }
 

--- a/packages/hydrated_cubit/pubspec.yaml
+++ b/packages/hydrated_cubit/pubspec.yaml
@@ -1,6 +1,6 @@
 name: hydrated_cubit
 description: An extension to the cubit state management library which automatically persists and restores cubit states.
-version: 0.0.2
+version: 0.0.3
 homepage: https://github.com/felangel/cubit
 
 environment:

--- a/packages/hydrated_cubit/test/hydrated_cubit_test.dart
+++ b/packages/hydrated_cubit/test/hydrated_cubit_test.dart
@@ -5,7 +5,7 @@ import 'package:hydrated_cubit/hydrated_cubit.dart';
 import 'package:cubit/cubit.dart';
 import 'package:uuid/uuid.dart';
 
-class MockStorage extends Mock implements HydratedCubitStorage {}
+class MockStorage extends Mock implements Storage {}
 
 class MockCubit extends Mock implements HydratedCubit<dynamic> {
   @override
@@ -57,7 +57,7 @@ class MyMultiHydratedCubit extends HydratedCubit<int> {
 void main() {
   TestWidgetsFlutterBinding.ensureInitialized();
   group('HydratedCubit', () {
-    MockStorage storage;
+    Storage storage;
 
     setUp(() {
       storage = MockStorage();
@@ -86,7 +86,7 @@ void main() {
           'HydratedStorage was accessed before it was initialized.\n'
           'Please ensure that storage has been initialized.\n\n'
           'For example:\n\n'
-          'HydratedCubit.storage = await HydratedCubitStorage.getInstance();',
+          'HydratedCubit.storage = await HydratedStorage.build();',
         );
       });
 


### PR DESCRIPTION
- **BREAKING**:
  - Rename `HydratedStorage` to `Storage`
  - Rename `HydratedCubitStorage` to `HydratedStorage`
  - Rename `getInstance` to `build`

Updated Usage:

```dart
void main() async {
  WidgetsFlutterBinding.ensureInitialized();
  HydratedCubit.storage = await HydratedStorage.build();
  runApp(App());
}
```