### PR TITLE
feat(replay_cubit)!: ReplayMixin

### DIFF
--- a/packages/replay_cubit/CHANGELOG.md
+++ b/packages/replay_cubit/CHANGELOG.md
@@ -1,7 +1,7 @@
 # 0.2.0
 
 - **BREAKING**: rename `clear` to `clearHistory`
-- feat: `ReplayCubitMixin`
+- feat: `ReplayMixin`
 
 # 0.1.0
 

--- a/packages/replay_cubit/CHANGELOG.md
+++ b/packages/replay_cubit/CHANGELOG.md
@@ -1,3 +1,8 @@
+# 0.2.0
+
+- **BREAKING**: rename `clear` to `clearHistory`
+- feat: `ReplayCubitMixin`
+
 # 0.1.0
 
 - feat: initial release

--- a/packages/replay_cubit/README.md
+++ b/packages/replay_cubit/README.md
@@ -41,6 +41,25 @@ void main() {
 }
 ```
 
+## ReplayCubitMixin
+
+If you wish to be able to use a `ReplayCubit` in conjuction with a different type of cubit like `HydratedCubit`, you can use the `ReplayCubitMixin`.
+
+```dart
+class CounterCubit extends HydratedCubit<int> with ReplayCubitMixin<int> {
+  CounterCubit() : super(0);
+
+  void increment() => emit(state + 1);
+  void decrement() => emit(state - 1);
+
+  @override
+  int fromJson(Map<String, dynamic> json) => json['value'] as int;
+
+  @override
+  Map<String, int> toJson(int state) => {'value': state};
+}
+```
+
 ## Dart Versions
 
 - Dart 2: >= 2.7.0

--- a/packages/replay_cubit/README.md
+++ b/packages/replay_cubit/README.md
@@ -41,12 +41,12 @@ void main() {
 }
 ```
 
-## ReplayCubitMixin
+## ReplayMixin
 
-If you wish to be able to use a `ReplayCubit` in conjuction with a different type of cubit like `HydratedCubit`, you can use the `ReplayCubitMixin`.
+If you wish to be able to use a `ReplayCubit` in conjuction with a different type of cubit like `HydratedCubit`, you can use the `ReplayMixin`.
 
 ```dart
-class CounterCubit extends HydratedCubit<int> with ReplayCubitMixin<int> {
+class CounterCubit extends HydratedCubit<int> with ReplayMixin<int> {
   CounterCubit() : super(0);
 
   void increment() => emit(state + 1);

--- a/packages/replay_cubit/example/ios/Flutter/Debug.xcconfig
+++ b/packages/replay_cubit/example/ios/Flutter/Debug.xcconfig
@@ -1,1 +1,2 @@
+#include "Pods/Target Support Files/Pods-Runner/Pods-Runner.debug.xcconfig"
 #include "Generated.xcconfig"

--- a/packages/replay_cubit/example/ios/Flutter/Release.xcconfig
+++ b/packages/replay_cubit/example/ios/Flutter/Release.xcconfig
@@ -1,1 +1,2 @@
+#include "Pods/Target Support Files/Pods-Runner/Pods-Runner.release.xcconfig"
 #include "Generated.xcconfig"

--- a/packages/replay_cubit/example/ios/Podfile
+++ b/packages/replay_cubit/example/ios/Podfile
@@ -1,0 +1,87 @@
+# Uncomment this line to define a global platform for your project
+# platform :ios, '9.0'
+
+# CocoaPods analytics sends network stats synchronously affecting flutter build latency.
+ENV['COCOAPODS_DISABLE_STATS'] = 'true'
+
+project 'Runner', {
+  'Debug' => :debug,
+  'Profile' => :release,
+  'Release' => :release,
+}
+
+def parse_KV_file(file, separator='=')
+  file_abs_path = File.expand_path(file)
+  if !File.exists? file_abs_path
+    return [];
+  end
+  generated_key_values = {}
+  skip_line_start_symbols = ["#", "/"]
+  File.foreach(file_abs_path) do |line|
+    next if skip_line_start_symbols.any? { |symbol| line =~ /^\s*#{symbol}/ }
+    plugin = line.split(pattern=separator)
+    if plugin.length == 2
+      podname = plugin[0].strip()
+      path = plugin[1].strip()
+      podpath = File.expand_path("#{path}", file_abs_path)
+      generated_key_values[podname] = podpath
+    else
+      puts "Invalid plugin specification: #{line}"
+    end
+  end
+  generated_key_values
+end
+
+target 'Runner' do
+  use_frameworks!
+  use_modular_headers!
+
+  # Flutter Pod
+
+  copied_flutter_dir = File.join(__dir__, 'Flutter')
+  copied_framework_path = File.join(copied_flutter_dir, 'Flutter.framework')
+  copied_podspec_path = File.join(copied_flutter_dir, 'Flutter.podspec')
+  unless File.exist?(copied_framework_path) && File.exist?(copied_podspec_path)
+    # Copy Flutter.framework and Flutter.podspec to Flutter/ to have something to link against if the xcode backend script has not run yet.
+    # That script will copy the correct debug/profile/release version of the framework based on the currently selected Xcode configuration.
+    # CocoaPods will not embed the framework on pod install (before any build phases can generate) if the dylib does not exist.
+
+    generated_xcode_build_settings_path = File.join(copied_flutter_dir, 'Generated.xcconfig')
+    unless File.exist?(generated_xcode_build_settings_path)
+      raise "Generated.xcconfig must exist. If you're running pod install manually, make sure flutter pub get is executed first"
+    end
+    generated_xcode_build_settings = parse_KV_file(generated_xcode_build_settings_path)
+    cached_framework_dir = generated_xcode_build_settings['FLUTTER_FRAMEWORK_DIR'];
+
+    unless File.exist?(copied_framework_path)
+      FileUtils.cp_r(File.join(cached_framework_dir, 'Flutter.framework'), copied_flutter_dir)
+    end
+    unless File.exist?(copied_podspec_path)
+      FileUtils.cp(File.join(cached_framework_dir, 'Flutter.podspec'), copied_flutter_dir)
+    end
+  end
+
+  # Keep pod path relative so it can be checked into Podfile.lock.
+  pod 'Flutter', :path => 'Flutter'
+
+  # Plugin Pods
+
+  # Prepare symlinks folder. We use symlinks to avoid having Podfile.lock
+  # referring to absolute paths on developers' machines.
+  system('rm -rf .symlinks')
+  system('mkdir -p .symlinks/plugins')
+  plugin_pods = parse_KV_file('../.flutter-plugins')
+  plugin_pods.each do |name, path|
+    symlink = File.join('.symlinks', 'plugins', name)
+    File.symlink(path, symlink)
+    pod name, :path => File.join(symlink, 'ios')
+  end
+end
+
+post_install do |installer|
+  installer.pods_project.targets.each do |target|
+    target.build_configurations.each do |config|
+      config.build_settings['ENABLE_BITCODE'] = 'NO'
+    end
+  end
+end

--- a/packages/replay_cubit/example/ios/Podfile.lock
+++ b/packages/replay_cubit/example/ios/Podfile.lock
@@ -1,0 +1,34 @@
+PODS:
+  - Flutter (1.0.0)
+  - path_provider (0.0.1):
+    - Flutter
+  - path_provider_linux (0.0.1):
+    - Flutter
+  - path_provider_macos (0.0.1):
+    - Flutter
+
+DEPENDENCIES:
+  - Flutter (from `Flutter`)
+  - path_provider (from `.symlinks/plugins/path_provider/ios`)
+  - path_provider_linux (from `.symlinks/plugins/path_provider_linux/ios`)
+  - path_provider_macos (from `.symlinks/plugins/path_provider_macos/ios`)
+
+EXTERNAL SOURCES:
+  Flutter:
+    :path: Flutter
+  path_provider:
+    :path: ".symlinks/plugins/path_provider/ios"
+  path_provider_linux:
+    :path: ".symlinks/plugins/path_provider_linux/ios"
+  path_provider_macos:
+    :path: ".symlinks/plugins/path_provider_macos/ios"
+
+SPEC CHECKSUMS:
+  Flutter: 0e3d915762c693b495b44d77113d4970485de6ec
+  path_provider: abfe2b5c733d04e238b0d8691db0cfd63a27a93c
+  path_provider_linux: 4d630dc393e1f20364f3e3b4a2ff41d9674a84e4
+  path_provider_macos: f760a3c5b04357c380e2fddb6f9db6f3015897e0
+
+PODFILE CHECKSUM: c34e2287a9ccaa606aeceab922830efb9a6ff69a
+
+COCOAPODS: 1.9.3

--- a/packages/replay_cubit/example/ios/Runner.xcodeproj/project.pbxproj
+++ b/packages/replay_cubit/example/ios/Runner.xcodeproj/project.pbxproj
@@ -10,6 +10,7 @@
 		1498D2341E8E89220040F4C2 /* GeneratedPluginRegistrant.m in Sources */ = {isa = PBXBuildFile; fileRef = 1498D2331E8E89220040F4C2 /* GeneratedPluginRegistrant.m */; };
 		3B3967161E833CAA004F5970 /* AppFrameworkInfo.plist in Resources */ = {isa = PBXBuildFile; fileRef = 3B3967151E833CAA004F5970 /* AppFrameworkInfo.plist */; };
 		74858FAF1ED2DC5600515810 /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 74858FAE1ED2DC5600515810 /* AppDelegate.swift */; };
+		82CE5E69B225F092F6ADEECF /* Pods_Runner.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = C11D41C849D25A03B182B9FB /* Pods_Runner.framework */; };
 		97C146FC1CF9000F007C117D /* Main.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 97C146FA1CF9000F007C117D /* Main.storyboard */; };
 		97C146FE1CF9000F007C117D /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 97C146FD1CF9000F007C117D /* Assets.xcassets */; };
 		97C147011CF9000F007C117D /* LaunchScreen.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 97C146FF1CF9000F007C117D /* LaunchScreen.storyboard */; };
@@ -32,9 +33,11 @@
 		1498D2321E8E86230040F4C2 /* GeneratedPluginRegistrant.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = GeneratedPluginRegistrant.h; sourceTree = "<group>"; };
 		1498D2331E8E89220040F4C2 /* GeneratedPluginRegistrant.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = GeneratedPluginRegistrant.m; sourceTree = "<group>"; };
 		3B3967151E833CAA004F5970 /* AppFrameworkInfo.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; name = AppFrameworkInfo.plist; path = Flutter/AppFrameworkInfo.plist; sourceTree = "<group>"; };
+		5464D43BACAC92B245E7EF9D /* Pods-Runner.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Runner.release.xcconfig"; path = "Target Support Files/Pods-Runner/Pods-Runner.release.xcconfig"; sourceTree = "<group>"; };
 		74858FAD1ED2DC5600515810 /* Runner-Bridging-Header.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "Runner-Bridging-Header.h"; sourceTree = "<group>"; };
 		74858FAE1ED2DC5600515810 /* AppDelegate.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = AppDelegate.swift; sourceTree = "<group>"; };
 		7AFA3C8E1D35360C0083082E /* Release.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; name = Release.xcconfig; path = Flutter/Release.xcconfig; sourceTree = "<group>"; };
+		9236D6613DEF89FC3E8211EE /* Pods-Runner.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Runner.debug.xcconfig"; path = "Target Support Files/Pods-Runner/Pods-Runner.debug.xcconfig"; sourceTree = "<group>"; };
 		9740EEB21CF90195004384FC /* Debug.xcconfig */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.xcconfig; name = Debug.xcconfig; path = Flutter/Debug.xcconfig; sourceTree = "<group>"; };
 		9740EEB31CF90195004384FC /* Generated.xcconfig */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.xcconfig; name = Generated.xcconfig; path = Flutter/Generated.xcconfig; sourceTree = "<group>"; };
 		97C146EE1CF9000F007C117D /* Runner.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = Runner.app; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -42,6 +45,8 @@
 		97C146FD1CF9000F007C117D /* Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Assets.xcassets; sourceTree = "<group>"; };
 		97C147001CF9000F007C117D /* Base */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; name = Base; path = Base.lproj/LaunchScreen.storyboard; sourceTree = "<group>"; };
 		97C147021CF9000F007C117D /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
+		C11D41C849D25A03B182B9FB /* Pods_Runner.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_Runner.framework; sourceTree = BUILT_PRODUCTS_DIR; };
+		F582A540AF29FD56C35D36FF /* Pods-Runner.profile.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Runner.profile.xcconfig"; path = "Target Support Files/Pods-Runner/Pods-Runner.profile.xcconfig"; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -49,12 +54,21 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				82CE5E69B225F092F6ADEECF /* Pods_Runner.framework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
 /* End PBXFrameworksBuildPhase section */
 
 /* Begin PBXGroup section */
+		31E37B1B309D5892897DF770 /* Frameworks */ = {
+			isa = PBXGroup;
+			children = (
+				C11D41C849D25A03B182B9FB /* Pods_Runner.framework */,
+			);
+			name = Frameworks;
+			sourceTree = "<group>";
+		};
 		9740EEB11CF90186004384FC /* Flutter */ = {
 			isa = PBXGroup;
 			children = (
@@ -72,6 +86,8 @@
 				9740EEB11CF90186004384FC /* Flutter */,
 				97C146F01CF9000F007C117D /* Runner */,
 				97C146EF1CF9000F007C117D /* Products */,
+				9EE3620EF11B331E0C33ADF5 /* Pods */,
+				31E37B1B309D5892897DF770 /* Frameworks */,
 			);
 			sourceTree = "<group>";
 		};
@@ -106,6 +122,17 @@
 			name = "Supporting Files";
 			sourceTree = "<group>";
 		};
+		9EE3620EF11B331E0C33ADF5 /* Pods */ = {
+			isa = PBXGroup;
+			children = (
+				9236D6613DEF89FC3E8211EE /* Pods-Runner.debug.xcconfig */,
+				5464D43BACAC92B245E7EF9D /* Pods-Runner.release.xcconfig */,
+				F582A540AF29FD56C35D36FF /* Pods-Runner.profile.xcconfig */,
+			);
+			name = Pods;
+			path = Pods;
+			sourceTree = "<group>";
+		};
 /* End PBXGroup section */
 
 /* Begin PBXNativeTarget section */
@@ -113,12 +140,14 @@
 			isa = PBXNativeTarget;
 			buildConfigurationList = 97C147051CF9000F007C117D /* Build configuration list for PBXNativeTarget "Runner" */;
 			buildPhases = (
+				7460B870E652A0388F5B05A7 /* [CP] Check Pods Manifest.lock */,
 				9740EEB61CF901F6004384FC /* Run Script */,
 				97C146EA1CF9000F007C117D /* Sources */,
 				97C146EB1CF9000F007C117D /* Frameworks */,
 				97C146EC1CF9000F007C117D /* Resources */,
 				9705A1C41CF9048500538489 /* Embed Frameworks */,
 				3B06AD1E1E4923F5004D2608 /* Thin Binary */,
+				0BBA18216A65E0DF2C36BC9A /* [CP] Embed Pods Frameworks */,
 			);
 			buildRules = (
 			);
@@ -177,6 +206,26 @@
 /* End PBXResourcesBuildPhase section */
 
 /* Begin PBXShellScriptBuildPhase section */
+		0BBA18216A65E0DF2C36BC9A /* [CP] Embed Pods Frameworks */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputPaths = (
+				"${PODS_ROOT}/Target Support Files/Pods-Runner/Pods-Runner-frameworks.sh",
+				"${PODS_ROOT}/../Flutter/Flutter.framework",
+				"${BUILT_PRODUCTS_DIR}/path_provider/path_provider.framework",
+			);
+			name = "[CP] Embed Pods Frameworks";
+			outputPaths = (
+				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/Flutter.framework",
+				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/path_provider.framework",
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "\"${PODS_ROOT}/Target Support Files/Pods-Runner/Pods-Runner-frameworks.sh\"\n";
+			showEnvVarsInLog = 0;
+		};
 		3B06AD1E1E4923F5004D2608 /* Thin Binary */ = {
 			isa = PBXShellScriptBuildPhase;
 			buildActionMask = 2147483647;
@@ -190,6 +239,28 @@
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
 			shellScript = "/bin/sh \"$FLUTTER_ROOT/packages/flutter_tools/bin/xcode_backend.sh\" embed_and_thin";
+		};
+		7460B870E652A0388F5B05A7 /* [CP] Check Pods Manifest.lock */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputFileListPaths = (
+			);
+			inputPaths = (
+				"${PODS_PODFILE_DIR_PATH}/Podfile.lock",
+				"${PODS_ROOT}/Manifest.lock",
+			);
+			name = "[CP] Check Pods Manifest.lock";
+			outputFileListPaths = (
+			);
+			outputPaths = (
+				"$(DERIVED_FILE_DIR)/Pods-Runner-checkManifestLockResult.txt",
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "diff \"${PODS_PODFILE_DIR_PATH}/Podfile.lock\" \"${PODS_ROOT}/Manifest.lock\" > /dev/null\nif [ $? != 0 ] ; then\n    # print error to STDERR\n    echo \"error: The sandbox is not in sync with the Podfile.lock. Run 'pod install' or update your CocoaPods installation.\" >&2\n    exit 1\nfi\n# This output is used by Xcode 'outputs' to avoid re-running this script phase.\necho \"SUCCESS\" > \"${SCRIPT_OUTPUT_FILE_0}\"\n";
+			showEnvVarsInLog = 0;
 		};
 		9740EEB61CF901F6004384FC /* Run Script */ = {
 			isa = PBXShellScriptBuildPhase;

--- a/packages/replay_cubit/example/ios/Runner.xcworkspace/contents.xcworkspacedata
+++ b/packages/replay_cubit/example/ios/Runner.xcworkspace/contents.xcworkspacedata
@@ -4,4 +4,7 @@
    <FileRef
       location = "group:Runner.xcodeproj">
    </FileRef>
+   <FileRef
+      location = "group:Pods/Pods.xcodeproj">
+   </FileRef>
 </Workspace>

--- a/packages/replay_cubit/example/lib/main.dart
+++ b/packages/replay_cubit/example/lib/main.dart
@@ -100,7 +100,7 @@ class CounterPage extends StatelessWidget {
 /// and exposes three public methods to `increment`, `decrement`, and
 /// `reset` the value of the state.
 /// {@endtemplate}
-class CounterCubit extends HydratedCubit<int> with ReplayCubitMixin<int> {
+class CounterCubit extends HydratedCubit<int> with ReplayMixin<int> {
   /// {@macro replay_counter_cubit}
   CounterCubit() : super(0);
 

--- a/packages/replay_cubit/example/lib/main.dart
+++ b/packages/replay_cubit/example/lib/main.dart
@@ -1,9 +1,14 @@
 import 'package:flutter/material.dart';
 
 import 'package:flutter_cubit/flutter_cubit.dart';
+import 'package:hydrated_cubit/hydrated_cubit.dart';
 import 'package:replay_cubit/replay_cubit.dart';
 
-void main() => runApp(App());
+void main() async {
+  WidgetsFlutterBinding.ensureInitialized();
+  HydratedCubit.storage = await HydratedStorage.build();
+  runApp(App());
+}
 
 /// A [StatelessWidget] which uses:
 /// * [replay_cubit](https://pub.dev/packages/replay_cubit)
@@ -80,7 +85,8 @@ class CounterPage extends StatelessWidget {
               child: const Icon(Icons.delete_forever),
               onPressed: () => context.cubit<CounterCubit>()
                 ..reset()
-                ..clear(),
+                ..clear()
+                ..clearHistory(),
             ),
           ),
         ],
@@ -94,7 +100,7 @@ class CounterPage extends StatelessWidget {
 /// and exposes three public methods to `increment`, `decrement`, and
 /// `reset` the value of the state.
 /// {@endtemplate}
-class CounterCubit extends ReplayCubit<int> {
+class CounterCubit extends HydratedCubit<int> with ReplayCubitMixin<int> {
   /// {@macro replay_counter_cubit}
   CounterCubit() : super(0);
 
@@ -106,4 +112,10 @@ class CounterCubit extends ReplayCubit<int> {
 
   /// Resets the `cubit` state to 0.
   void reset() => emit(0);
+
+  @override
+  int fromJson(Map<String, dynamic> json) => json['value'] as int;
+
+  @override
+  Map<String, int> toJson(int state) => {'value': state};
 }

--- a/packages/replay_cubit/example/pubspec.yaml
+++ b/packages/replay_cubit/example/pubspec.yaml
@@ -8,10 +8,12 @@ environment:
 dependencies:
   flutter:
     sdk: flutter
-  replay_cubit:
-    path: ..
   flutter_cubit:
     path: ../../flutter_cubit
+  hydrated_cubit:
+    path: ../../hydrated_cubit
+  replay_cubit:
+    path: ../
 
 flutter:
   uses-material-design: true

--- a/packages/replay_cubit/lib/src/replay_cubit.dart
+++ b/packages/replay_cubit/lib/src/replay_cubit.dart
@@ -49,11 +49,9 @@ abstract class ReplayCubit<State> extends Cubit<State> with ReplayMixin<State> {
 }
 
 mixin ReplayMixin<State> on CubitStream<State> {
-  set limit(int limit) {
-    _changeStack.limit = limit;
-  }
-
   final _changeStack = _ChangeStack<State>();
+
+  set limit(int limit) => _changeStack.limit = limit;
 
   @override
   void emit(State state) {

--- a/packages/replay_cubit/lib/src/replay_cubit.dart
+++ b/packages/replay_cubit/lib/src/replay_cubit.dart
@@ -41,15 +41,14 @@ part 'change_stack.dart';
 /// * [Cubit] for information about the [ReplayCubit] superclass.
 ///
 /// {@endtemplate}
-abstract class ReplayCubit<State> extends Cubit<State>
-    with ReplayCubitMixin<State> {
+abstract class ReplayCubit<State> extends Cubit<State> with ReplayMixin<State> {
   /// {@macro replay_cubit}
   ReplayCubit(State state, {int limit}) : super(state) {
     this.limit = limit;
   }
 }
 
-mixin ReplayCubitMixin<State> on Cubit<State> {
+mixin ReplayMixin<State> on CubitStream<State> {
   set limit(int limit) {
     _changeStack.limit = limit;
   }

--- a/packages/replay_cubit/lib/src/replay_cubit.dart
+++ b/packages/replay_cubit/lib/src/replay_cubit.dart
@@ -41,13 +41,20 @@ part 'change_stack.dart';
 /// * [Cubit] for information about the [ReplayCubit] superclass.
 ///
 /// {@endtemplate}
-abstract class ReplayCubit<State> extends Cubit<State> {
+abstract class ReplayCubit<State> extends Cubit<State>
+    with ReplayCubitMixin<State> {
   /// {@macro replay_cubit}
-  ReplayCubit(State state, {int limit})
-      : _changeStack = _ChangeStack<State>(limit: limit),
-        super(state);
+  ReplayCubit(State state, {int limit}) : super(state) {
+    this.limit = limit;
+  }
+}
 
-  final _ChangeStack _changeStack;
+mixin ReplayCubitMixin<State> on Cubit<State> {
+  set limit(int limit) {
+    _changeStack.limit = limit;
+  }
+
+  final _changeStack = _ChangeStack<State>();
 
   @override
   void emit(State state) {
@@ -71,5 +78,5 @@ abstract class ReplayCubit<State> extends Cubit<State> {
   bool get canRedo => _changeStack.canRedo;
 
   /// Clear undo/redo history
-  void clear() => _changeStack.clear();
+  void clearHistory() => _changeStack.clear();
 }

--- a/packages/replay_cubit/pubspec.yaml
+++ b/packages/replay_cubit/pubspec.yaml
@@ -4,7 +4,7 @@ repository: https://github.com/felangel/cubit
 issue_tracker: https://github.com/felangel/cubit/issues
 homepage: https://github.com/felangel/cubit
 
-version: 0.1.0
+version: 0.2.0
 
 environment:
   sdk: ">=2.7.0 <3.0.0"

--- a/packages/replay_cubit/test/cubits/counter_cubit.dart
+++ b/packages/replay_cubit/test/cubits/counter_cubit.dart
@@ -1,7 +1,17 @@
+import 'package:cubit/cubit.dart';
 import 'package:replay_cubit/replay_cubit.dart';
 
 class CounterCubit extends ReplayCubit<int> {
   CounterCubit({int limit}) : super(0, limit: limit);
+
+  void increment() => emit(state + 1);
+  void decrement() => emit(state - 1);
+}
+
+class CounterCubitMixin extends Cubit<int> with ReplayCubitMixin<int> {
+  CounterCubitMixin({int limit}) : super(0) {
+    this.limit = limit;
+  }
 
   void increment() => emit(state + 1);
   void decrement() => emit(state - 1);

--- a/packages/replay_cubit/test/cubits/counter_cubit.dart
+++ b/packages/replay_cubit/test/cubits/counter_cubit.dart
@@ -8,7 +8,7 @@ class CounterCubit extends ReplayCubit<int> {
   void decrement() => emit(state - 1);
 }
 
-class CounterCubitMixin extends Cubit<int> with ReplayCubitMixin<int> {
+class CounterCubitMixin extends Cubit<int> with ReplayMixin<int> {
   CounterCubitMixin({int limit}) : super(0) {
     this.limit = limit;
   }

--- a/packages/replay_cubit/test/replay_cubit_test.dart
+++ b/packages/replay_cubit/test/replay_cubit_test.dart
@@ -5,7 +5,7 @@ import 'package:test/test.dart';
 import 'cubits/counter_cubit.dart';
 
 void main() {
-  group('cubit', () {
+  group('ReplayCubit', () {
     group('initial state', () {
       test('is correct', () {
         expect(CounterCubit().state, 0);
@@ -60,9 +60,9 @@ void main() {
       });
     });
 
-    group('clear', () {
-      test('resets history and redos on new cubit', () async {
-        final cubit = CounterCubit()..clear();
+    group('clearHistory', () {
+      test('clears history and redos on new cubit', () async {
+        final cubit = CounterCubit()..clearHistory();
         expect(cubit.canRedo, isFalse);
         expect(cubit.canUndo, isFalse);
         await cubit.close();
@@ -183,6 +183,197 @@ void main() {
           'followed by a new state change', () async {
         final states = <int>[];
         final cubit = CounterCubit();
+        final subscription = cubit.listen(states.add);
+        await Future<void>.delayed(Duration.zero, cubit.increment);
+        await Future<void>.delayed(Duration.zero, cubit.increment);
+        await Future<void>.delayed(Duration.zero, cubit.undo);
+        await Future<void>.delayed(Duration.zero, cubit.decrement);
+        await Future<void>.delayed(Duration.zero, cubit.redo);
+        await cubit.close();
+        await subscription.cancel();
+        expect(states, [0, 1, 2, 1, 0]);
+      });
+    });
+  });
+
+  group('ReplayCubitMixin', () {
+    group('initial state', () {
+      test('is correct', () {
+        expect(CounterCubitMixin().state, 0);
+      });
+    });
+
+    group('canUndo', () {
+      test('is false when no state changes have occurred', () async {
+        final cubit = CounterCubitMixin();
+        expect(cubit.canUndo, isFalse);
+        await cubit.close();
+      });
+
+      test('is true when a single state change has occurred', () async {
+        final cubit = CounterCubitMixin();
+        await Future<void>.delayed(Duration.zero, cubit.increment);
+        expect(cubit.canUndo, isTrue);
+        await cubit.close();
+      });
+
+      test('is false when undos have been exhausted', () async {
+        final cubit = CounterCubitMixin();
+        await Future<void>.delayed(Duration.zero, cubit.increment);
+        await Future<void>.delayed(Duration.zero, cubit.undo);
+        expect(cubit.canUndo, isFalse);
+        await cubit.close();
+      });
+    });
+
+    group('canRedo', () {
+      test('is false when no state changes have occurred', () async {
+        final cubit = CounterCubitMixin();
+        expect(cubit.canRedo, isFalse);
+        await cubit.close();
+      });
+
+      test('is true when a single undo has occurred', () async {
+        final cubit = CounterCubitMixin();
+        await Future<void>.delayed(Duration.zero, cubit.increment);
+        await Future<void>.delayed(Duration.zero, cubit.undo);
+        expect(cubit.canRedo, isTrue);
+        await cubit.close();
+      });
+
+      test('is false when redos have been exhausted', () async {
+        final cubit = CounterCubitMixin();
+        await Future<void>.delayed(Duration.zero, cubit.increment);
+        await Future<void>.delayed(Duration.zero, cubit.undo);
+        await Future<void>.delayed(Duration.zero, cubit.redo);
+        expect(cubit.canRedo, isFalse);
+        await cubit.close();
+      });
+    });
+
+    group('clearHistory', () {
+      test('clears history and redos on new cubit', () async {
+        final cubit = CounterCubitMixin()..clearHistory();
+        expect(cubit.canRedo, isFalse);
+        expect(cubit.canUndo, isFalse);
+        await cubit.close();
+      });
+    });
+
+    group('undo', () {
+      test('does nothing when no state changes have occurred', () async {
+        final states = <int>[];
+        final cubit = CounterCubitMixin();
+        final subscription = cubit.listen(states.add);
+        await Future<void>.delayed(Duration.zero, cubit.undo);
+        await cubit.close();
+        await subscription.cancel();
+        expect(states, [0]);
+      });
+
+      test('does nothing when limit is 0', () async {
+        final states = <int>[];
+        final cubit = CounterCubitMixin(limit: 0);
+        final subscription = cubit.listen(states.add);
+        await Future<void>.delayed(Duration.zero, cubit.increment);
+        await Future<void>.delayed(Duration.zero, cubit.undo);
+        await cubit.close();
+        await subscription.cancel();
+        expect(states, [0, 1]);
+      });
+
+      test('loses history outside of limit', () async {
+        final states = <int>[];
+        final cubit = CounterCubitMixin(limit: 1);
+        final subscription = cubit.listen(states.add);
+        await Future<void>.delayed(Duration.zero, cubit.increment);
+        await Future<void>.delayed(Duration.zero, cubit.increment);
+        await Future<void>.delayed(Duration.zero, cubit.undo);
+        await Future<void>.delayed(Duration.zero, cubit.undo);
+        await cubit.close();
+        await subscription.cancel();
+        expect(states, [0, 1, 2, 1]);
+      });
+
+      test('reverts to initial state', () async {
+        final states = <int>[];
+        final cubit = CounterCubitMixin();
+        final subscription = cubit.listen(states.add);
+        await Future<void>.delayed(Duration.zero, cubit.increment);
+        await Future<void>.delayed(Duration.zero, cubit.undo);
+        await cubit.close();
+        await subscription.cancel();
+        expect(states, [0, 1, 0]);
+      });
+
+      test('reverts to previous state with multiple state changes ', () async {
+        final states = <int>[];
+        final cubit = CounterCubitMixin();
+        final subscription = cubit.listen(states.add);
+        await Future<void>.delayed(Duration.zero, cubit.increment);
+        await Future<void>.delayed(Duration.zero, cubit.increment);
+        await Future<void>.delayed(Duration.zero, cubit.undo);
+        await cubit.close();
+        await subscription.cancel();
+        expect(states, [0, 1, 2, 1]);
+      });
+    });
+
+    group('redo', () {
+      test('does nothing when no state changes have occurred', () async {
+        final states = <int>[];
+        final cubit = CounterCubitMixin();
+        final subscription = cubit.listen(states.add);
+        await Future<void>.delayed(Duration.zero, cubit.redo);
+        await cubit.close();
+        await subscription.cancel();
+        expect(states, [0]);
+      });
+
+      test('does nothing when no undos have occurred', () async {
+        final states = <int>[];
+        final cubit = CounterCubitMixin();
+        final subscription = cubit.listen(states.add);
+        await Future<void>.delayed(Duration.zero, cubit.increment);
+        await Future<void>.delayed(Duration.zero, cubit.increment);
+        await Future<void>.delayed(Duration.zero, cubit.redo);
+        await cubit.close();
+        await subscription.cancel();
+        expect(states, [0, 1, 2]);
+      });
+
+      test('works when one undo has occurred', () async {
+        final states = <int>[];
+        final cubit = CounterCubitMixin();
+        final subscription = cubit.listen(states.add);
+        await Future<void>.delayed(Duration.zero, cubit.increment);
+        await Future<void>.delayed(Duration.zero, cubit.increment);
+        await Future<void>.delayed(Duration.zero, cubit.undo);
+        await Future<void>.delayed(Duration.zero, cubit.redo);
+        await cubit.close();
+        await subscription.cancel();
+        expect(states, [0, 1, 2, 1, 2]);
+      });
+
+      test('does nothing when undos have been exhausted', () async {
+        final states = <int>[];
+        final cubit = CounterCubitMixin();
+        final subscription = cubit.listen(states.add);
+        await Future<void>.delayed(Duration.zero, cubit.increment);
+        await Future<void>.delayed(Duration.zero, cubit.increment);
+        await Future<void>.delayed(Duration.zero, cubit.undo);
+        await Future<void>.delayed(Duration.zero, cubit.redo);
+        await Future<void>.delayed(Duration.zero, cubit.redo);
+        await cubit.close();
+        await subscription.cancel();
+        expect(states, [0, 1, 2, 1, 2]);
+      });
+
+      test(
+          'does nothing when undos has occurred '
+          'followed by a new state change', () async {
+        final states = <int>[];
+        final cubit = CounterCubitMixin();
         final subscription = cubit.listen(states.add);
         await Future<void>.delayed(Duration.zero, cubit.increment);
         await Future<void>.delayed(Duration.zero, cubit.increment);

--- a/packages/replay_cubit/test/replay_cubit_test.dart
+++ b/packages/replay_cubit/test/replay_cubit_test.dart
@@ -196,7 +196,7 @@ void main() {
     });
   });
 
-  group('ReplayCubitMixin', () {
+  group('ReplayMixin', () {
     group('initial state', () {
       test('is correct', () {
         expect(CounterCubitMixin().state, 0);


### PR DESCRIPTION
- **BREAKING**: rename `clear` to `clearHistory`
  - required to avoid naming collision with `clear` on `HydratedCubit`
- feat: `ReplayMixin`

```dart
class CounterCubit extends HydratedCubit<int> with ReplayMixin<int> {
  CounterCubit() : super(0);

  void increment() => emit(state + 1);
  void decrement() => emit(state - 1);

  @override
  int fromJson(Map<String, dynamic> json) => json['value'] as int;

  @override
  Map<String, int> toJson(int state) => {'value': state};
}
```

I'm also leaning towards renaming `clear` on `HydratedCubit` to something more descriptive like `clearStorage` in a subsequent PR where we add support for `HydratedCubitMixin`.

@rodydavis if you have time, I would love a review 👍 