### PR TITLE
Coping with "file being used by another process" errors

### DIFF
--- a/packages/hydrated_cubit/pubspec.yaml
+++ b/packages/hydrated_cubit/pubspec.yaml
@@ -22,3 +22,4 @@ dev_dependencies:
   mockito: ^4.0.0
   pedantic: ^1.9.0
   uuid: ^2.0.4
+  path: ^1.6.4

--- a/packages/hydrated_cubit/test/hydrated_storage_test.dart
+++ b/packages/hydrated_cubit/test/hydrated_storage_test.dart
@@ -5,6 +5,7 @@ import 'package:flutter_test/flutter_test.dart';
 import 'package:hive/hive.dart';
 import 'package:hydrated_cubit/hydrated_cubit.dart';
 import 'package:mockito/mockito.dart';
+import 'package:path/path.dart' as p;
 import 'package:path_provider/path_provider.dart';
 import 'package:pedantic/pedantic.dart';
 
@@ -63,7 +64,7 @@ void main() {
         final box = Hive.box<dynamic>('hydrated_box');
         final directory = await getTemporaryDirectory();
         expect(box, isNotNull);
-        expect(box.path, '${directory.path}/hydrated_box.hive');
+        expect(box.path, p.join(directory.path, 'hydrated_box.hive'));
       });
     });
 

--- a/packages/hydrated_cubit/test/hydrated_storage_test.dart
+++ b/packages/hydrated_cubit/test/hydrated_storage_test.dart
@@ -27,16 +27,16 @@ void main() {
         throw UnimplementedError();
       });
 
-    group('build', () {
-      Storage storage;
+    Storage storage;
 
+    tearDown(() async {
+      await storage?.clear();
+    });
+
+    group('build', () {
       setUp(() async {
         await (await HydratedStorage.build()).clear();
         getTemporaryDirectoryCallCount = 0;
-      });
-
-      tearDownAll(() async {
-        await storage?.clear();
       });
 
       test('calls getTemporaryDirectory when storageDirectory is null',
@@ -74,15 +74,10 @@ void main() {
       const key = '__key__';
       const value = '__value__';
       Box box;
-      Storage storage;
 
       setUp(() {
         box = MockBox();
         storage = HydratedStorage(box);
-      });
-
-      tearDownAll(() async {
-        await storage?.clear();
       });
 
       group('read', () {
@@ -143,12 +138,6 @@ void main() {
     });
 
     group('During heavy load', () {
-      Storage storage;
-
-      tearDownAll(() async {
-        await storage?.clear();
-      });
-
       test('writes key/value pairs correctly', () async {
         const token = 'token';
         storage = await HydratedStorage.build(

--- a/packages/hydrated_cubit/test/hydrated_storage_test.dart
+++ b/packages/hydrated_cubit/test/hydrated_storage_test.dart
@@ -28,30 +28,32 @@ void main() {
       });
 
     group('build', () {
+      Storage storage;
+
       setUp(() async {
         await (await HydratedStorage.build()).clear();
         getTemporaryDirectoryCallCount = 0;
       });
 
       tearDownAll(() async {
-        await Hive.deleteBoxFromDisk('hydrated_box');
+        await storage?.clear();
       });
 
       test('calls getTemporaryDirectory when storageDirectory is null',
           () async {
-        await HydratedStorage.build();
+        storage = await HydratedStorage.build();
         expect(getTemporaryDirectoryCallCount, 1);
       });
 
       test(
           'does not call getTemporaryDirectory '
           'when storageDirectory is defined', () async {
-        await HydratedStorage.build(storageDirectory: Directory(cwd));
+        storage = await HydratedStorage.build(storageDirectory: Directory(cwd));
         expect(getTemporaryDirectoryCallCount, 0);
       });
 
       test('reuses existing instance when called multiple times', () async {
-        final instanceA = await HydratedStorage.build();
+        final instanceA = storage = await HydratedStorage.build();
         final beforeCount = getTemporaryDirectoryCallCount;
         final instanceB = await HydratedStorage.build();
         final afterCount = getTemporaryDirectoryCallCount;
@@ -60,7 +62,7 @@ void main() {
       });
 
       test('calls Hive.init with correct directory', () async {
-        await HydratedStorage.build();
+        storage = await HydratedStorage.build();
         final box = Hive.box<dynamic>('hydrated_box');
         final directory = await getTemporaryDirectory();
         expect(box, isNotNull);
@@ -80,7 +82,7 @@ void main() {
       });
 
       tearDownAll(() async {
-        await storage.clear();
+        await storage?.clear();
       });
 
       group('read', () {
@@ -144,7 +146,7 @@ void main() {
       Storage storage;
 
       tearDownAll(() async {
-        await storage.clear();
+        await storage?.clear();
       });
 
       test('writes key/value pairs correctly', () async {


### PR DESCRIPTION
I've encountered several problems just running `flutter test -j 1`:
- test expected `...\\hydrated_cubit\\test/hydrated_box.hive` path, but found `...\\hydrated_cubit\\test\\hydrated_box.hive`  
fixed this by adding `package:path`
- was getting "lock failed, another process has locked a portion of the file" in 2 places  
fixed by moving around `tearDownAll` 