### PR TITLE
fix(hydrated_cubit): support use alongside hive

### DIFF
--- a/packages/hydrated_cubit/lib/src/hydrated_storage.dart
+++ b/packages/hydrated_cubit/lib/src/hydrated_storage.dart
@@ -54,7 +54,7 @@ class HydratedStorage implements Storage {
     return _lock.synchronized(() async {
       if (_instance != null) return _instance;
       final directory = storageDirectory ?? await getTemporaryDirectory();
-      // Need to use HiveImpl directly to avoid conflicts with existing Hive initialization
+      // Use HiveImpl directly to avoid conflicts with existing Hive.init
       // https://github.com/hivedb/hive/issues/336
       hive = HiveImpl();
       if (!kIsWeb) hive.init(directory.path);

--- a/packages/hydrated_cubit/lib/src/hydrated_storage.dart
+++ b/packages/hydrated_cubit/lib/src/hydrated_storage.dart
@@ -54,6 +54,8 @@ class HydratedStorage implements Storage {
     return _lock.synchronized(() async {
       if (_instance != null) return _instance;
       final directory = storageDirectory ?? await getTemporaryDirectory();
+      // Need to use HiveImpl directly to avoid conflicts with existing Hive initialization
+      // https://github.com/hivedb/hive/issues/336
       hive = HiveImpl();
       if (!kIsWeb) hive.init(directory.path);
       final box = await hive.openBox<dynamic>(
@@ -64,7 +66,8 @@ class HydratedStorage implements Storage {
     });
   }
 
-  /// Own instance of HiveImpl, to resolve interference
+  /// Internal instance of [HiveImpl].
+  /// It should only be used for testing.
   @visibleForTesting
   static HiveInterface hive;
 

--- a/packages/hydrated_cubit/lib/src/hydrated_storage.dart
+++ b/packages/hydrated_cubit/lib/src/hydrated_storage.dart
@@ -4,6 +4,8 @@ import 'package:flutter/foundation.dart';
 import 'package:hive/hive.dart';
 import 'package:path_provider/path_provider.dart';
 import 'package:synchronized/synchronized.dart';
+// ignore: implementation_imports
+import 'package:hive/src/hive_impl.dart';
 
 import 'hydrated_cipher.dart';
 
@@ -52,14 +54,19 @@ class HydratedStorage implements Storage {
     return _lock.synchronized(() async {
       if (_instance != null) return _instance;
       final directory = storageDirectory ?? await getTemporaryDirectory();
-      if (!kIsWeb) Hive.init(directory.path);
-      final box = await Hive.openBox<dynamic>(
+      hive = HiveImpl();
+      if (!kIsWeb) hive.init(directory.path);
+      final box = await hive.openBox<dynamic>(
         'hydrated_box',
         encryptionCipher: encryptionCipher,
       );
       return _instance = HydratedStorage(box);
     });
   }
+
+  /// Own instance of HiveImpl, to resolve interference
+  @visibleForTesting
+  static HiveInterface hive;
 
   static final _lock = Lock();
   static HydratedStorage _instance;

--- a/packages/hydrated_cubit/test/hive_interference_test.dart
+++ b/packages/hydrated_cubit/test/hive_interference_test.dart
@@ -1,0 +1,94 @@
+import 'dart:io';
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:hive/hive.dart';
+import 'package:path/path.dart' as p;
+
+// ignore: implementation_imports
+import 'package:hive/src/hive_impl.dart';
+
+void main() {
+  group('Hive interference', () {
+    test('Odd singleton interference', () async {
+      final cwd = Directory.current.absolute.path;
+
+      final impl1 = Hive..init(cwd);
+      var box1 = await impl1.openBox<dynamic>('impl1');
+
+      final impl2 = Hive..init(cwd);
+      var box2 = await impl2.openBox<dynamic>('impl2');
+
+      await impl1.close();
+
+      expect(box1.isOpen, true);
+      expect(box2.isOpen, false);
+
+      await box1.deleteFromDisk();
+      await Hive.deleteBoxFromDisk('impl2');
+    });
+
+    test('Two hive impls beside same directory', () async {
+      final cwd = Directory.current.absolute.path;
+
+      final impl1 = Hive..init(cwd);
+      var box1 = await impl1.openBox<dynamic>('impl1');
+
+      final impl2 = HiveImpl()..init(cwd);
+      var box2 = await impl2.openBox<dynamic>('impl2');
+
+      await box1.put('instance', 'impl1');
+      await box2.put('instance', 'impl2');
+
+      await impl1.close();
+      await impl2.close();
+
+      box1 = await impl1.openBox<dynamic>('impl1');
+      box2 = await impl2.openBox<dynamic>('impl2');
+
+      expect(box1.get('instance'), 'impl1');
+      expect(box2.get('instance'), 'impl2');
+
+      await impl1.deleteFromDisk();
+      expect(box1.isOpen, false);
+      expect(box2.isOpen, true);
+      expect(box2.get('instance'), 'impl2');
+
+      await impl2.deleteFromDisk();
+      expect(box2.isOpen, false);
+    });
+
+    test('Two hive impls reside distinct directories', () async {
+      final cwd1 = p.join(Directory.current.absolute.path, 'cwd1');
+      final cwd2 = p.join(Directory.current.absolute.path, 'cwd2');
+
+      final impl1 = Hive..init(cwd1);
+      var box1 = await impl1.openBox<dynamic>('impl1');
+
+      final impl2 = HiveImpl()..init(cwd2);
+      var box2 = await impl2.openBox<dynamic>('impl2');
+
+      await box1.put('instance', 'impl1');
+      await box2.put('instance', 'impl2');
+
+      await impl1.close();
+      await impl2.close();
+
+      box1 = await impl1.openBox<dynamic>('impl1');
+      box2 = await impl2.openBox<dynamic>('impl2');
+
+      expect(box1.get('instance'), 'impl1');
+      expect(box2.get('instance'), 'impl2');
+
+      await impl1.deleteFromDisk();
+      expect(box1.isOpen, false);
+      expect(box2.isOpen, true);
+      expect(box2.get('instance'), 'impl2');
+
+      await impl2.deleteFromDisk();
+      expect(box2.isOpen, false);
+
+      await Directory(cwd1).delete();
+      await Directory(cwd2).delete();
+    });
+  });
+}

--- a/packages/hydrated_cubit/test/hive_interference_test.dart
+++ b/packages/hydrated_cubit/test/hive_interference_test.dart
@@ -9,7 +9,7 @@ import 'package:hive/src/hive_impl.dart';
 
 void main() {
   group('Hive interference', () {
-    test('Odd singleton interference', () async {
+    test('odd singleton interference', () async {
       final cwd = Directory.current.absolute.path;
 
       final impl1 = Hive..init(cwd);
@@ -27,7 +27,7 @@ void main() {
       await Hive.deleteBoxFromDisk('impl2');
     });
 
-    test('Two hive impls beside same directory', () async {
+    test('two hive impls beside same directory', () async {
       final cwd = Directory.current.absolute.path;
 
       final impl1 = Hive..init(cwd);
@@ -57,7 +57,7 @@ void main() {
       expect(box2.isOpen, false);
     });
 
-    test('Two hive impls reside distinct directories', () async {
+    test('two hive impls reside distinct directories', () async {
       final cwd1 = p.join(Directory.current.absolute.path, 'cwd1');
       final cwd2 = p.join(Directory.current.absolute.path, 'cwd2');
 

--- a/packages/hydrated_cubit/test/hydrated_storage_test.dart
+++ b/packages/hydrated_cubit/test/hydrated_storage_test.dart
@@ -61,7 +61,7 @@ void main() {
         expect(instanceA, instanceB);
       });
 
-      test('creates own HiveImpl with correct directory', () async {
+      test('creates internal HiveImpl with correct directory', () async {
         storage = await HydratedStorage.build();
         final box = HydratedStorage.hive?.box<dynamic>('hydrated_box');
         final directory = await getTemporaryDirectory();

--- a/packages/hydrated_cubit/test/hydrated_storage_test.dart
+++ b/packages/hydrated_cubit/test/hydrated_storage_test.dart
@@ -61,9 +61,9 @@ void main() {
         expect(instanceA, instanceB);
       });
 
-      test('calls Hive.init with correct directory', () async {
+      test('creates own HiveImpl with correct directory', () async {
         storage = await HydratedStorage.build();
-        final box = Hive.box<dynamic>('hydrated_box');
+        final box = HydratedStorage.hive?.box<dynamic>('hydrated_box');
         final directory = await getTemporaryDirectory();
         expect(box, isNotNull);
         expect(box.path, p.join(directory.path, 'hydrated_box.hive'));


### PR DESCRIPTION
Basically when Hive is running alongside HydratedBloc, latest invocation of `Hive.init()` (which can occur inside HB, or somewhere in main) overrides previous Hive configuration.

We address this issue by using our own `HiveImpl` instance, which can live inside or outside Hive's default directory